### PR TITLE
add support for passing options to the transformer

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
 		"type": "git",
 		"url": "http://github.com/webpack/transform-loader.git"
 	},
+	"dependencies": {
+		"json5": "^0.4.0",
+		"loader-utils": "^0.2.6"
+	},
 	"devDependencies": {
-		"brfs": "~1.0.0",
+		"brfs": "~1.4.0",
 		"coffeeify": "~0.6.0"
 	},
 	"licenses": [

--- a/test/options.js
+++ b/test/options.js
@@ -1,0 +1,4 @@
+var fs = require("fs");
+var filename = "not-exists.txt";
+var text = fs.readFileSync(filename, "utf-8");
+module.exports = text;

--- a/test/test.js
+++ b/test/test.js
@@ -2,3 +2,4 @@ var fs = require("fs");
 var text = fs.readFileSync(__dirname + "/file.txt", "utf-8");
 document.write(text);
 document.write(require("./test.coffee"));
+document.write(require("./options.js"));

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -10,6 +10,10 @@ module.exports = {
 			{
 				test: /\.coffee$/,
 				loader: __dirname + "/../cacheable?coffeeify"
+			},
+			{
+				test: /options\.js$/,
+				loader: __dirname + "/../cacheable?brfs=>{vars: { filename: './test/file.txt' } }"
 			}
 		]
 	}


### PR DESCRIPTION
I've been working with `brfs` and found that it only statically analyzes a few types of dynamic paths (mostly related to `path.join` and `__dirname`).  However, you can pass an options object as the 2nd parameter and give it a `vars` key that maps your variables to paths.  This PR adds the ability to define the options object as part of the loader query.  I've tried my best to match your style based on `imports-loader`.
