### PR TITLE
add index options

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,9 @@ module.exports = function(input) {
 	var resource = this.resource;
 	var loaderContext = this;
 	var q = Object.keys(query)[0];
-	if(/^[0-9]+$/.test(q)) {
-		next(this.options.transforms[+q]);
+	var reg = /^[0-9]+$/;
+	if(reg.test(q) || reg.test(query.index)) {
+		next(query.transforms[query.index]);
 	} else {
 		this.resolve(this.context, q, function(err, module) {
 			if(err) return callback(err);


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Use `webpack.LoaderOptionsPlugin` may not be a good idea.

Because `webpack.LoaderOptionsPlugin` may change the loader's context.For example, when i use `css-loader` to generate css-module code, at this time `loader-utils` will use `this.context` to generate style's hash [loader-utils#L265](https://github.com/webpack/loader-utils/blob/v0.2.17/index.js#L265).So when i use webpack multi entries to build an universal-react app, 
This problem may lead to generate different css-hash(because i use `transform-loader` only in the client entry), it might be `header__logo___1WE56` and `header__logo__2USE`

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

So we should use `loader.options` to avoid this problem. I add a new option `index` to assign the current transform, used like:
```js
{
  loader: 'transform-loader',
  options: {
    index: 0,
    transforms: [
      function(file) {
        return brfs(file, { parserOpts: { allowImportExportEverywhere: true } });
      }
    ]
  }
}
```

### Additional Info

It's just an idea, if you think it will be ok, i will update the README later.😃